### PR TITLE
Changing Drink to Mixins

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mc_version=1.20.1
 jei_version=15.2.0.23
-mod_version=1.20.1-1.4.0-arkveil
+mod_version=1.20.1-1.3.14

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mc_version=1.20.1
 jei_version=15.2.0.23
-mod_version=1.20.1-1.3.13
+mod_version=1.20.1-1.4.0-arkveil

--- a/src/main/java/dev/ghen/thirst/Thirst.java
+++ b/src/main/java/dev/ghen/thirst/Thirst.java
@@ -1,8 +1,8 @@
 package dev.ghen.thirst;
 
 import dev.ghen.thirst.api.ThirstHelper;
-import dev.ghen.thirst.compat.create.CreateRegistry;
-import dev.ghen.thirst.compat.create.ponder.ThirstPonders;
+//import dev.ghen.thirst.compat.create.CreateRegistry;
+//import dev.ghen.thirst.compat.create.ponder.ThirstPonders;
 import dev.ghen.thirst.content.purity.WaterPurity;
 import dev.ghen.thirst.content.registry.ItemInit;
 import dev.ghen.thirst.content.thirst.PlayerThirst;
@@ -51,10 +51,10 @@ public class Thirst
 
         ItemInit.ITEMS.register(modBus);
 
-        if(ModList.get().isLoaded("create"))
-        {
-            CreateRegistry.register();
-        }
+       // if(ModList.get().isLoaded("create"))
+        //{
+        //    CreateRegistry.register();
+        //}
 
         ThirstTab.register(modBus);
 
@@ -92,9 +92,9 @@ public class Thirst
 
     private void clientSetup(final FMLClientSetupEvent event)
     {
-        if(ModList.get().isLoaded("create")){
-            event.enqueueWork(ThirstPonders::register);
-        }
+        //if(ModList.get().isLoaded("create")){
+            //event.enqueueWork(ThirstPonders::register);
+        //}
 
         if(ModList.get().isLoaded("vampirism"))
         {

--- a/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirst.java
+++ b/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirst.java
@@ -2,7 +2,9 @@ package dev.ghen.thirst.content.thirst;
 
 import de.teamlapen.vampirism.util.Helper;
 import dev.ghen.thirst.api.ThirstHelper;
+import dev.ghen.thirst.content.purity.WaterPurity;
 import dev.ghen.thirst.foundation.common.capability.IThirst;
+import dev.ghen.thirst.foundation.common.capability.ModCapabilities;
 import dev.ghen.thirst.foundation.common.damagesource.ModDamageSource;
 import dev.ghen.thirst.foundation.config.CommonConfig;
 import dev.ghen.thirst.foundation.network.ThirstModPacketHandler;
@@ -13,6 +15,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.network.PacketDistributor;
 import vectorwing.farmersdelight.common.registry.ModEffects;
 
@@ -34,6 +37,23 @@ public class PlayerThirst implements IThirst
     boolean shouldTickThirst = true;
     boolean exhaustionRecalculate = false;
     boolean init = true;
+
+    /**
+     * Attempts to give hydration to player if item restores thirst.
+     * @param item
+     * @param player
+     */
+    public static void drink(ItemStack item, Player player)
+    {
+        if(ThirstHelper.itemRestoresThirst(item))
+        {
+            player.getCapability(ModCapabilities.PLAYER_THIRST,null).ifPresent(cap ->
+            {
+                if(WaterPurity.givePurityEffects(player, item))
+                    cap.drink(player, ThirstHelper.getThirst(item), ThirstHelper.getQuenched(item));
+            });
+        }
+    }
 
     public int getThirst()
     {

--- a/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirstManager.java
+++ b/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirstManager.java
@@ -87,7 +87,7 @@ public class PlayerThirstManager
             DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> DrinkByHandClient::drinkByHand);
     }
 
-    @SubscribeEvent
+    /*@SubscribeEvent
     public static void drink(LivingEntityUseItemEvent.Finish event)
     {
         if(event.getEntity() instanceof Player && ThirstHelper.itemRestoresThirst(event.getItem()))
@@ -99,7 +99,7 @@ public class PlayerThirstManager
                     cap.drink((Player) event.getEntity(), ThirstHelper.getThirst(item), ThirstHelper.getQuenched(item));
             });
         }
-    }
+    }*/
 
     @SubscribeEvent
     public static void onPlayerTick(TickEvent.PlayerTickEvent event)

--- a/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirstManager.java
+++ b/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirstManager.java
@@ -87,20 +87,6 @@ public class PlayerThirstManager
             DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> DrinkByHandClient::drinkByHand);
     }
 
-    /*@SubscribeEvent
-    public static void drink(LivingEntityUseItemEvent.Finish event)
-    {
-        if(event.getEntity() instanceof Player && ThirstHelper.itemRestoresThirst(event.getItem()))
-        {
-            event.getEntity().getCapability(ModCapabilities.PLAYER_THIRST).ifPresent(cap ->
-            {
-                ItemStack item = event.getItem();
-                if(WaterPurity.givePurityEffects((Player) event.getEntity(), item))
-                    cap.drink((Player) event.getEntity(), ThirstHelper.getThirst(item), ThirstHelper.getQuenched(item));
-            });
-        }
-    }*/
-
     @SubscribeEvent
     public static void onPlayerTick(TickEvent.PlayerTickEvent event)
     {

--- a/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPlayer.java
+++ b/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPlayer.java
@@ -1,0 +1,31 @@
+package dev.ghen.thirst.foundation.mixin;
+
+import dev.ghen.thirst.content.thirst.PlayerThirst;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.LazyOptional;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Player.class)
+public abstract class MixinPlayer
+{
+
+
+    @Shadow public abstract <T> LazyOptional<T> getCapability(Capability<T> capability, @Nullable Direction facing);
+
+    @Inject(method = "eat", at = @At("HEAD"))
+    public void onEatDrink(Level level, ItemStack item, CallbackInfoReturnable<ItemStack> cir)
+    {
+        Player player = (Player) ((Object) this);
+        PlayerThirst.drink(item, player);
+    }
+
+}

--- a/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPlayer.java
+++ b/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPlayer.java
@@ -18,7 +18,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinPlayer
 {
 
-
     @Shadow public abstract <T> LazyOptional<T> getCapability(Capability<T> capability, @Nullable Direction facing);
 
     @Inject(method = "eat", at = @At("HEAD"))

--- a/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPotionItem.java
+++ b/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPotionItem.java
@@ -1,12 +1,19 @@
 package dev.ghen.thirst.foundation.mixin;
 
+import dev.ghen.thirst.content.thirst.PlayerThirst;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.PotionItem;
+import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(PotionItem.class)
 public class MixinPotionItem {
@@ -16,5 +23,11 @@ public class MixinPotionItem {
         ItemEntity itemEntity = new ItemEntity(instance.player.level(), instance.player.getX(), instance.player.getY(), instance.player.getZ(), stack);
         instance.player.level().addFreshEntity(itemEntity);
         return true;
+    }
+
+    @Inject(method = "finishUsingItem", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void onFinishUsingItem(ItemStack item, Level level, LivingEntity livingEntity, CallbackInfoReturnable<ItemStack> cir, Player player)
+    {
+        PlayerThirst.drink(item, player);
     }
 }

--- a/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
+++ b/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
@@ -54,8 +54,8 @@ public class ThirstTab
         list.add(ItemInit.TERRACOTTA_WATER_BOWL.get().getDefaultInstance());
 
         // for some fucking reason the game crashes if you don't do it here
-        if(ModList.get().isLoaded("create"))
-            list.add(CreateRegistry.SAND_FILTER_BLOCK.asStack());
+        //if(ModList.get().isLoaded("create"))
+            //list.add(CreateRegistry.SAND_FILTER_BLOCK.asStack());
 
         return list;
     }

--- a/src/main/resources/thirst.mixin.json
+++ b/src/main/resources/thirst.mixin.json
@@ -16,6 +16,7 @@
     "MixinItemStack",
     "MixinLayeredCauldronBlock",
     "MixinPotionItem",
+    "MixinPlayer",
     "accessors.brewinandchewin.KegBlockEntityAccessor",
     "brewinandchewin.MixinKegBlockEntity",
     "brewinandchewin.MixinKegFermentingRecipe",


### PR DESCRIPTION
Following vanilla behaviors, property updates like thirst or hunger should occur before the LivingEntityUseItem#Finish event occurs. These changes should fix cases where another mod contains a drinkable or edible item in a tool like a lunchbox and lets the player drink it.

Also temporarily disabled the create compat so it can be launched with Create 6.0