### PR TITLE
Fix: Drinking last potion doesn't check for purity

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mc_version=1.20.1
 jei_version=15.19.0.91
-mod_version=1.20.1-1.3.16
+mod_version=1.20.1-1.3.15

--- a/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirstManager.java
+++ b/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirstManager.java
@@ -93,23 +93,15 @@ public class PlayerThirstManager
     @SubscribeEvent
     public static void drink(LivingEntityUseItemEvent.Finish event)
     {
-        if(event.getItem().getItem() instanceof PotionItem)
-            return;
-        if(event.getItem().getItem().isEdible())
-            return;
-        if(event.getItem().getItem() instanceof DrinkableItem)
-            return;
-
         if(event.getEntity() instanceof Player && ThirstHelper.itemRestoresThirst(event.getItem()))
         {
-            event.getEntity().getCapability(ModCapabilities.PLAYER_THIRST).ifPresent(cap ->
-            {
-                ItemStack item = event.getItem();
-                if(WaterPurity.givePurityEffects((Player) event.getEntity(), item)){
-
-                    cap.drink((Player) event.getEntity(), ThirstHelper.getThirst(item), ThirstHelper.getQuenched(item));
-                }
-            });
+            if(event.getItem().getItem() instanceof PotionItem)
+                return;
+            if(event.getItem().getItem().isEdible())
+                return;
+            if(event.getItem().getItem() instanceof DrinkableItem)
+                return;
+            PlayerThirst.drink(event.getItem(), (Player) event.getEntity());
         }
     }
 

--- a/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirstManager.java
+++ b/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirstManager.java
@@ -1,17 +1,18 @@
 package dev.ghen.thirst.content.thirst;
 
-import dev.ghen.thirst.Thirst;
 import dev.ghen.thirst.api.ThirstHelper;
-import dev.ghen.thirst.content.purity.WaterPurity;
 import dev.ghen.thirst.foundation.common.capability.IThirst;
 import dev.ghen.thirst.foundation.common.capability.ModCapabilities;
+import dev.ghen.thirst.foundation.common.item.DrinkableItem;
 import dev.ghen.thirst.foundation.config.CommonConfig;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.Foods;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.PotionItem;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -26,6 +27,8 @@ import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.common.Mod;
+import dev.ghen.thirst.Thirst;
+import dev.ghen.thirst.content.purity.WaterPurity;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -90,7 +93,11 @@ public class PlayerThirstManager
     @SubscribeEvent
     public static void drink(LivingEntityUseItemEvent.Finish event)
     {
+        if(event.getItem().getItem() instanceof PotionItem)
+            return;
         if(event.getItem().getItem().isEdible())
+            return;
+        if(event.getItem().getItem() instanceof DrinkableItem)
             return;
 
         if(event.getEntity() instanceof Player && ThirstHelper.itemRestoresThirst(event.getItem()))
@@ -99,6 +106,7 @@ public class PlayerThirstManager
             {
                 ItemStack item = event.getItem();
                 if(WaterPurity.givePurityEffects((Player) event.getEntity(), item)){
+
                     cap.drink((Player) event.getEntity(), ThirstHelper.getThirst(item), ThirstHelper.getQuenched(item));
                 }
             });

--- a/src/main/java/dev/ghen/thirst/foundation/common/item/DrinkableItem.java
+++ b/src/main/java/dev/ghen/thirst/foundation/common/item/DrinkableItem.java
@@ -1,5 +1,6 @@
 package dev.ghen.thirst.foundation.common.item;
 
+import dev.ghen.thirst.content.thirst.PlayerThirst;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.stats.Stats;
@@ -49,6 +50,10 @@ public class DrinkableItem extends Item
         if (player instanceof ServerPlayer)
         {
             CriteriaTriggers.CONSUME_ITEM.trigger((ServerPlayer)player, item);
+        }
+        if(player != null)
+        {
+            PlayerThirst.drink(item, player);
         }
 
         if (player != null)

--- a/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPlayer.java
+++ b/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPlayer.java
@@ -1,6 +1,5 @@
 package dev.ghen.thirst.foundation.mixin;
 
-import dev.ghen.thirst.content.purity.WaterPurity;
 import dev.ghen.thirst.content.thirst.PlayerThirst;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -17,7 +16,6 @@ public abstract class MixinPlayer
     public void onEatDrink(Level level, ItemStack item, CallbackInfoReturnable<ItemStack> cir)
     {
         Player player = (Player) ((Object) this);
-        WaterPurity.givePurityEffects(player, item);
         PlayerThirst.drink(item, player);
     }
 

--- a/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPotionItem.java
+++ b/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPotionItem.java
@@ -1,6 +1,8 @@
 package dev.ghen.thirst.foundation.mixin;
 
 import dev.ghen.thirst.content.thirst.PlayerThirst;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -25,9 +27,10 @@ public class MixinPotionItem {
         return true;
     }
 
-    @Inject(method = "finishUsingItem", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD)
-    public void onFinishUsingItem(ItemStack item, Level level, LivingEntity livingEntity, CallbackInfoReturnable<ItemStack> cir, Player player)
+    @Inject(method = "finishUsingItem", at = @At("HEAD"), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void onFinishUsingItem(ItemStack item, Level level, LivingEntity livingEntity, CallbackInfoReturnable<ItemStack> cir)
     {
+        Player player = livingEntity instanceof Player ? (Player)livingEntity : null;
         if(player != null)
         {
             PlayerThirst.drink(item, player);

--- a/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPotionItem.java
+++ b/src/main/java/dev/ghen/thirst/foundation/mixin/MixinPotionItem.java
@@ -1,11 +1,18 @@
 package dev.ghen.thirst.foundation.mixin;
 
+import dev.ghen.thirst.content.thirst.PlayerThirst;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.PotionItem;
+import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(PotionItem.class)
 public class MixinPotionItem {
@@ -16,5 +23,14 @@ public class MixinPotionItem {
             instance.player.drop(stack, false);
         }
         return true;
+    }
+
+    @Inject(method = "finishUsingItem", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void onFinishUsingItem(ItemStack item, Level level, LivingEntity livingEntity, CallbackInfoReturnable<ItemStack> cir, Player player)
+    {
+        if(player != null)
+        {
+            PlayerThirst.drink(item, player);
+        }
     }
 }


### PR DESCRIPTION
Reverted redundant purity checks. 

Moved the mixin check to head of finishusingitem in Potion.class. Should more reliably detect potions for drinking while maintaining lunchbox fix.