### PR TITLE
-Added Supernatural Compatibility.

### DIFF
--- a/src/main/java/dev/ghen/thirst/api/ThirstHelper.java
+++ b/src/main/java/dev/ghen/thirst/api/ThirstHelper.java
@@ -1,6 +1,7 @@
 package dev.ghen.thirst.api;
 
 import com.momosoftworks.coldsweat.api.util.Temperature;
+import dev.ghen.thirst.compat.supernatural.SupernaturalHelper;
 import dev.ghen.thirst.content.purity.ContainerWithPurity;
 import dev.ghen.thirst.content.purity.WaterPurity;
 import dev.ghen.thirst.content.registry.ThirstComponent;
@@ -12,6 +13,7 @@ import dev.ghen.thirst.foundation.config.ItemSettingsConfig;
 import dev.ghen.thirst.foundation.config.KeyWordConfig;
 import dev.ghen.thirst.foundation.util.ConfigHelper;
 import dev.ghen.thirst.foundation.util.LoadedValue;
+import net.neoforged.fml.ModList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.effect.MobEffects;
@@ -63,6 +65,15 @@ public class ThirstHelper
     {
         return isDrink(itemStack) ||
                 isFood(itemStack) || checkKeywords(itemStack);
+    }
+
+    public static boolean playerRestoresThirst(ItemStack itemStack, Player player)
+    {
+        if (ModList.get().isLoaded("supernatural"))
+        {
+            return SupernaturalHelper.canDrinkItem(itemStack, player);
+        }
+        return true;
     }
 
     public static boolean isDrink(ItemStack itemStack)

--- a/src/main/java/dev/ghen/thirst/compat/supernatural/SupernaturalHelper.java
+++ b/src/main/java/dev/ghen/thirst/compat/supernatural/SupernaturalHelper.java
@@ -1,0 +1,38 @@
+package dev.ghen.thirst.compat.supernatural;
+
+import net.salju.supernatural.init.SupernaturalItems;
+import net.salju.supernatural.init.SupernaturalTags;
+import net.salju.supernatural.events.SupernaturalManager;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Item;
+
+public class SupernaturalHelper {
+    public static boolean canDrinkItem(ItemStack stack, Player player) {
+        if (isVampireCheck(player)) {
+            return isBloodCheck(stack);
+        } else {
+            return true;
+        }
+    }
+
+    //Checks for Persistent NBT Player Data for Vampirism. Serverside only.
+	public static boolean isVampireCheck(Player player) {
+        return SupernaturalManager.isVampire(player);
+    }
+
+    //Checks if the Player has the Vampirism MobEffect. Works on Clientside & Serverside.
+    public static boolean hasVampirismCheck(Player player) {
+        return SupernaturalManager.hasVampirism(player);
+    }
+
+    //Checks if the item is tagged as Blood. By default, it is just the Blood o' Blood item.
+    public static boolean isBloodCheck(ItemStack stack) {
+        return stack.is(SupernaturalTags.BLOOD);
+    }
+
+    //Grabs the Bottle o' Blood item.
+    public static Item getBloodBottle() {
+        return SupernaturalItems.BLOOD.get();
+    }
+}

--- a/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirst.java
+++ b/src/main/java/dev/ghen/thirst/content/thirst/PlayerThirst.java
@@ -85,7 +85,7 @@ public class PlayerThirst implements IThirst, INBTSerializable<CompoundTag>
      */
     public static void drink(ItemStack item, Player player)
     {
-        if(ThirstHelper.itemRestoresThirst(item))
+        if(ThirstHelper.itemRestoresThirst(item) && ThirstHelper.playerRestoresThirst(item, player))
         {
             player.getData(ModAttachment.PLAYER_THIRST).drink(ThirstHelper.getThirst(item),ThirstHelper.getQuenched(item));
         }

--- a/src/main/java/dev/ghen/thirst/foundation/config/ItemSettingsConfig.java
+++ b/src/main/java/dev/ghen/thirst/foundation/config/ItemSettingsConfig.java
@@ -61,6 +61,7 @@ public class ItemSettingsConfig
                                         Arrays.asList("collectorsreap:pink_limeade",8,13),
                                         Arrays.asList("collectorsreap:pomegranate_black_tea",10,14),
                                         Arrays.asList("collectorsreap:lime_green_tea",10,14),
+                                        Arrays.asList("supernatural:blood_bottle",9,12),
 
                                         Arrays.asList("toughasnails:dirty_water_bottle", 6, 8),
                                         Arrays.asList("toughasnails:purified_water_bottle", 8, 10),


### PR DESCRIPTION
This pull will do the following:
1. Adds an additional boolean to ThirstHelper that will always return true by default.

2. This boolean will check if the mod "Supernatural" is loaded, if so... It will then redirect the boolean to a new one in the SupernaturalHelper file that was also added.

3. The SupernaturalHelper file will have a boolean that checks if the player is a vampire. If not, it'll return true. If the player is a vampire, it will then check if the ItemStack is tagged as blood, and return a boolean of true if it is, false if it isn't.

4. This new boolean is used in PlayerThirst under the "drink" void to determine if a vampire player will get value from drinkable items or not. Due to how it works, the vampire player should ONLY get value from items tagged as blood within my own mod. Thus, vampires can become thirsty and will require blood in order to refill it.

5. Lastly, I added the Bottle o' Blood item to the config list to have thirst values of "9, 12". Nothing else is needed to be done as the item in question has everything else coded within my mod Supernatural already as is.

Note: I do want to modify the GUI texture to change the color of the droplets from water-coloring to blood-coloring but I decided not to touch that right now. However, the SupernaturalHelper does have a few unused checks that could be useful for this future feature, and perhaps other things if ever needed.