### PR TITLE
Un-Registrate the Sand Filter

### DIFF
--- a/src/main/java/dev/ghen/thirst/Thirst.java
+++ b/src/main/java/dev/ghen/thirst/Thirst.java
@@ -55,6 +55,8 @@ public class Thirst
 
         if(ModList.get().isLoaded("create"))
         {
+            CreateRegistry.BLOCKS.register(modBus);
+            CreateRegistry.BLOCK_ENTITY_TYPES.register(modBus);
             CreateRegistry.register();
         }
 

--- a/src/main/java/dev/ghen/thirst/compat/create/CreateRegistry.java
+++ b/src/main/java/dev/ghen/thirst/compat/create/CreateRegistry.java
@@ -1,33 +1,32 @@
 package dev.ghen.thirst.compat.create;
 
-import com.simibubi.create.content.processing.AssemblyOperatorBlockItem;
-import com.simibubi.create.foundation.data.AssetLookup;
-import com.simibubi.create.foundation.data.SharedProperties;
-import com.tterrag.registrate.Registrate;
-import com.tterrag.registrate.util.entry.BlockEntityEntry;
-import com.tterrag.registrate.util.entry.BlockEntry;
-import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import dev.ghen.thirst.Thirst;
+import dev.ghen.thirst.content.registry.ItemInit;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
 
-import static com.simibubi.create.foundation.data.ModelGen.customItemModel;
+import java.util.function.Supplier;
+
 
 public class CreateRegistry
 {
-    public static final NonNullSupplier<Registrate> REGISTRATE = NonNullSupplier.lazy(() ->Registrate.create(Thirst.ID));
-
+    public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(Thirst.ID);
+    public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_TYPES = DeferredRegister.create(BuiltInRegistries.BLOCK_ENTITY_TYPE, Thirst.ID);
     public static void register(){}
 
+    public static final DeferredHolder<Block, Block> SAND_FILTER_BLOCK = BLOCKS.register("sand_filter",
+                    () -> new SandFilterBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.COPPER_BLOCK)));
 
-    public static final BlockEntry<SandFilterBlock> SAND_FILTER_BLOCK = REGISTRATE.get()
-            .block("sand_filter", SandFilterBlock::new)
-            .initialProperties(SharedProperties::copperMetal)
-            .blockstate((ctx, prov) -> prov.simpleBlock(ctx.getEntry(), AssetLookup.partialBaseModel(ctx, prov)))
-            .item(AssemblyOperatorBlockItem::new)
-            .transform(customItemModel())
-            .register();
-    public static final BlockEntityEntry<SandFilterBlockEntity> SAND_FILTER_TE = REGISTRATE.get()
-            .blockEntity("sand_filter", SandFilterBlockEntity::new)
-            .validBlocks(SAND_FILTER_BLOCK)
-            .register();
+    public static final DeferredHolder<Item, Item> SAND_FILTER_ITEM = ItemInit.ITEMS.register("sand_filter",
+            () -> new BlockItem(SAND_FILTER_BLOCK.get(), new Item.Properties()));
 
+    public static final Supplier<BlockEntityType<SandFilterBlockEntity>> SAND_FILTER_BE = BLOCK_ENTITY_TYPES.register("sand_filter",
+            () -> BlockEntityType.Builder.of(SandFilterBlockEntity::new, SAND_FILTER_BLOCK.get()).build(null));
 }

--- a/src/main/java/dev/ghen/thirst/compat/create/SandFilterBlock.java
+++ b/src/main/java/dev/ghen/thirst/compat/create/SandFilterBlock.java
@@ -46,7 +46,7 @@ public class SandFilterBlock extends Block implements IWrenchable, IBE<SandFilte
     @Override
     public BlockEntityType<? extends SandFilterBlockEntity> getBlockEntityType()
     {
-        return CreateRegistry.SAND_FILTER_TE.get();
+        return CreateRegistry.SAND_FILTER_BE.get();
     }
 
 }

--- a/src/main/java/dev/ghen/thirst/compat/create/SandFilterBlockEntity.java
+++ b/src/main/java/dev/ghen/thirst/compat/create/SandFilterBlockEntity.java
@@ -29,9 +29,9 @@ public class SandFilterBlockEntity extends SmartBlockEntity implements IHaveGogg
     SmartFluidTankBehaviour dirtyTank;
     SmartFluidTankBehaviour purifiedTank;
 
-    public SandFilterBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state)
+    public SandFilterBlockEntity(BlockPos pos, BlockState state)
     {
-        super(type, pos, state);
+        super(CreateRegistry.SAND_FILTER_BE.get(), pos, state);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class SandFilterBlockEntity extends SmartBlockEntity implements IHaveGogg
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
         event.registerBlockEntity(
                 Capabilities.FluidHandler.BLOCK,
-                CreateRegistry.SAND_FILTER_TE.get(),
+                CreateRegistry.SAND_FILTER_BE.get(),
                 (be, side) -> {
                     if (side != null && side.getAxis() == Direction.Axis.Y)
                     {

--- a/src/main/java/dev/ghen/thirst/compat/create/ponder/ThirstPonders.java
+++ b/src/main/java/dev/ghen/thirst/compat/create/ponder/ThirstPonders.java
@@ -9,32 +9,37 @@ import dev.ghen.thirst.compat.create.CreateRegistry;
 import dev.ghen.thirst.compat.create.ponder.scene.SandFilterScene;
 import net.createmod.ponder.api.registration.PonderSceneRegistrationHelper;
 import net.createmod.ponder.api.registration.PonderTagRegistrationHelper;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Block;
 
 
 public class ThirstPonders {
     public static final ResourceLocation PURIFICATION = Thirst.asResource("purification");
 
     public static void registerTags(PonderTagRegistrationHelper<ResourceLocation> helper) {
-        PonderTagRegistrationHelper<RegistryEntry<?,?>> HELPER = helper.withKeyFunction(RegistryEntry::getId);
+        PonderTagRegistrationHelper<Block> HELPER = helper.withKeyFunction(BuiltInRegistries.BLOCK::getKey);
 
         HELPER.registerTag(PURIFICATION)
                 .addToIndex()
-                .item(CreateRegistry.SAND_FILTER_BLOCK, true, false)
+                .item(CreateRegistry.SAND_FILTER_BLOCK.get(), true, false)
                 .title("Purification")
                 .description("Components which purifying water")
                 .register();
     }
 
     public static void registerScenes(PonderSceneRegistrationHelper<ResourceLocation> helper) {
-        PonderSceneRegistrationHelper<ItemProviderEntry<?,?>> HELPER = helper.withKeyFunction(RegistryEntry::getId);
+        PonderSceneRegistrationHelper<Block> HELPER = helper.withKeyFunction(BuiltInRegistries.BLOCK::getKey);
 
         HELPER.addStoryBoard(
-                CreateRegistry.SAND_FILTER_BLOCK,
+                CreateRegistry.SAND_FILTER_BLOCK.get(),
                 "sand_filter",
                 SandFilterScene::filtering,
                 AllCreatePonderTags.FLUIDS,
                 PURIFICATION
         );
+
     }
+
+
 }

--- a/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
+++ b/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
@@ -55,10 +55,9 @@ public class ThirstTab
         list.add(WaterPurity.addPurity(new ItemStack(ItemInit.TERRACOTTA_WATER_BOWL.get()), 2));
         list.add(ItemInit.TERRACOTTA_WATER_BOWL.get().getDefaultInstance());
 
-//        if(ModList.get().isLoaded("create")){
-//            list.remove(CreateRegistry.SAND_FILTER_BLOCK.asItem().getDefaultInstance());
-//            list.add(CreateRegistry.SAND_FILTER_BLOCK.asItem().getDefaultInstance());
-//        }
+        if(ModList.get().isLoaded("create")){
+            list.add(CreateRegistry.SAND_FILTER_ITEM.get().getDefaultInstance());
+        }
 
         System.out.println(Arrays.toString(list.toArray()));
 

--- a/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
+++ b/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
@@ -17,6 +17,7 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 
 public class ThirstTab
@@ -54,9 +55,12 @@ public class ThirstTab
         list.add(WaterPurity.addPurity(new ItemStack(ItemInit.TERRACOTTA_WATER_BOWL.get()), 2));
         list.add(ItemInit.TERRACOTTA_WATER_BOWL.get().getDefaultInstance());
 
-        if(ModList.get().isLoaded("create")){
-            list.add(CreateRegistry.SAND_FILTER_BLOCK.asItem().getDefaultInstance());
-        }
+//        if(ModList.get().isLoaded("create")){
+//            list.remove(CreateRegistry.SAND_FILTER_BLOCK.asItem().getDefaultInstance());
+//            list.add(CreateRegistry.SAND_FILTER_BLOCK.asItem().getDefaultInstance());
+//        }
+
+        System.out.println(Arrays.toString(list.toArray()));
 
         return list;
     }

--- a/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
+++ b/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
@@ -1,6 +1,7 @@
 package dev.ghen.thirst.foundation.tab;
 
 import dev.ghen.thirst.Thirst;
+import dev.ghen.thirst.compat.create.CreateRegistry;
 import dev.ghen.thirst.content.purity.WaterPurity;
 import dev.ghen.thirst.content.registry.ItemInit;
 import net.minecraft.core.registries.Registries;
@@ -11,6 +12,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.alchemy.Potions;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
@@ -52,9 +54,9 @@ public class ThirstTab
         list.add(WaterPurity.addPurity(new ItemStack(ItemInit.TERRACOTTA_WATER_BOWL.get()), 2));
         list.add(ItemInit.TERRACOTTA_WATER_BOWL.get().getDefaultInstance());
 
-//        if(ModList.get().isLoaded("create")){
-//            list.add(CreateRegistry.SAND_FILTER_BLOCK.asItem().getDefaultInstance());
-//        }
+        if(ModList.get().isLoaded("create")){
+            list.add(CreateRegistry.SAND_FILTER_BLOCK.asItem().getDefaultInstance());
+        }
 
         return list;
     }

--- a/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
+++ b/src/main/java/dev/ghen/thirst/foundation/tab/ThirstTab.java
@@ -59,8 +59,6 @@ public class ThirstTab
             list.add(CreateRegistry.SAND_FILTER_ITEM.get().getDefaultInstance());
         }
 
-        System.out.println(Arrays.toString(list.toArray()));
-
         return list;
     }
 }


### PR DESCRIPTION
The Sand Filter registration was using Registrate for some reason. Due to this, it couldn't be added to the Thirst was Taken creative tab (which was registered normally). This caused the Sand Filter to not show in JEI. This PR turns the Sand Filter registration (block, block entity, and item) into the regular NeoForge method of registering these things. The Sand Filter is again added to the Thirst was Taken tab (if Create is installed) and thus JEI.
![image](https://github.com/user-attachments/assets/5e76d617-102f-486b-9874-1c3179f09004)
As is shown, Ponder still works.