### PR TITLE
Fix ponder crashes when calling FluidTankBlockEntity#getControllerBE

### DIFF
--- a/src/main/java/dev/ghen/thirst/compat/create/ponder/ThirstPonderPlugin.java
+++ b/src/main/java/dev/ghen/thirst/compat/create/ponder/ThirstPonderPlugin.java
@@ -1,6 +1,5 @@
 package dev.ghen.thirst.compat.create.ponder;
 
-import com.simibubi.create.foundation.ponder.PonderWorldBlockEntityFix;
 import dev.ghen.thirst.Thirst;
 import net.createmod.ponder.api.level.PonderLevel;
 import net.createmod.ponder.api.registration.PonderPlugin;
@@ -23,10 +22,5 @@ public class ThirstPonderPlugin implements PonderPlugin {
     @Override
     public void registerTags(@NotNull PonderTagRegistrationHelper<ResourceLocation> helper) {
         ThirstPonders.registerTags(helper);
-    }
-
-    @Override
-    public void onPonderLevelRestore(@NotNull PonderLevel ponderLevel) {
-        PonderWorldBlockEntityFix.fixControllerBlockEntities(ponderLevel);
     }
 }


### PR DESCRIPTION
`ThirstPonderPlugin#onPonderLevelRestore` calls `PonderWorldBlockEntityFix#fixControllerBlockEntities`, which causes controller BE position being adjusted twice. Because `PonderWorldBlockEntityFix#fixControllerBlockEntities` is applied globally (to all ponder plugins) instead of seperately.

I Found this issue from multiple crash reports of C:EI. For example: https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/issues/286